### PR TITLE
Initialize project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+backend/node_modules
+frontend/node_modules
+backend/dist
+frontend/.next
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Alpine Idle Startup
+
+This repository contains the basic startup for the **Alpine Idle** project.
+It includes a Fastify backend and a Next.js frontend, both written in TypeScript.
+
+## Development
+
+Install dependencies in each package with Node.js 22 or later and run the development servers:
+
+```bash
+npm install --workspaces
+npm run dev:backend # starts backend on port 3001 using tsx
+npm run dev:frontend # starts frontend on port 3000
+```
+
+The frontend is accessible at `http://localhost:3000` and the backend at
+`http://localhost:3001/ping`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "tsx watch server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "fastify": "^4.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "tsx": "^4.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,0 +1,19 @@
+import fastify from 'fastify';
+
+const app = fastify({ logger: true });
+
+app.get('/ping', async (_request, _reply) => {
+  return { pong: 'it works!' };
+});
+
+const start = async () => {
+  try {
+    await app.listen({ port: Number(process.env.PORT) || 3001, host: '0.0.0.0' });
+    app.log.info(`Server listening on ${app.server.address().port}`);
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+};
+
+start();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "module": "nodenext",
+    "target": "ES2023",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["server.ts"]
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+export {};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "@types/react": "^18.2.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to Alpine Idle</h1>
+      <p>The startup project is ready.</p>
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "alpine-idle",
+  "version": "1.0.0",
+  "description": "Alpine Idle game project startup",
+  "private": true,
+  "scripts": {
+    "dev:backend": "npm --prefix backend run dev",
+    "dev:frontend": "npm --prefix frontend run dev",
+    "start:backend": "npm --prefix backend run start",
+    "start:frontend": "npm --prefix frontend run start",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "workspaces": ["backend", "frontend"],
+  "engines": {
+    "node": ">=22"
+  }
+}


### PR DESCRIPTION
## Summary
- switch backend dev script to `tsx`
- target Node.js 22 with updated tsconfig settings
- require Node 22 or later in workspace package.json
- document Node.js 22 requirement and tsx usage in README

## Testing
- `npm install --workspaces` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684c64863de08331907d294dbfc9f12d