### PR TITLE
Add sample Fastify routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,25 @@ npm run dev:frontend # starts frontend on port 3000
 
 The frontend is accessible at `http://localhost:3000` and the backend at
 `http://localhost:3001/ping`.
+
+## Example API usage
+
+Here are some example `curl` commands for interacting with the new CRUD routes:
+
+```bash
+# Users
+curl http://localhost:3001/users
+curl -X POST http://localhost:3001/users \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice","email":"alice@example.com"}'
+curl -X PUT http://localhost:3001/users/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice Updated"}'
+curl -X DELETE http://localhost:3001/users/1
+
+# Items
+curl http://localhost:3001/items
+curl -X POST http://localhost:3001/items \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Sword","description":"Basic sword"}'
+```

--- a/backend/routes/items.ts
+++ b/backend/routes/items.ts
@@ -1,0 +1,126 @@
+import { FastifyPluginAsync } from 'fastify';
+
+export interface Item {
+  id: number;
+  name: string;
+  description: string;
+}
+
+const items: Item[] = [];
+let nextId = 1;
+
+const itemSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    name: { type: 'string' },
+    description: { type: 'string' },
+  },
+  required: ['id', 'name', 'description'],
+};
+
+const messageSchema = {
+  type: 'object',
+  properties: { message: { type: 'string' } },
+  required: ['message'],
+};
+
+const itemsRoutes: FastifyPluginAsync = async (app) => {
+  app.get<{ Reply: Item[] }>('/items', {
+    schema: { response: { 200: { type: 'array', items: itemSchema } } },
+  }, async () => items);
+
+  app.get<{ Params: { id: number }; Reply: Item | { message: string } }>('/items/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      response: {
+        200: itemSchema,
+        404: messageSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const item = items.find((i) => i.id === Number(request.params.id));
+    if (!item) {
+      return reply.code(404).send({ message: 'Item not found' });
+    }
+    return item;
+  });
+
+  app.post<{ Body: Omit<Item, 'id'>; Reply: Item }>('/items', {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+        },
+        required: ['name', 'description'],
+      },
+      response: { 200: itemSchema },
+    },
+  }, async (request) => {
+    const newItem: Item = { id: nextId++, ...request.body };
+    items.push(newItem);
+    return newItem;
+  });
+
+  app.put<{ Params: { id: number }; Body: Partial<Omit<Item, 'id'>>; Reply: Item | { message: string } }>('/items/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          description: { type: 'string' },
+        },
+      },
+      response: {
+        200: itemSchema,
+        404: messageSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const item = items.find((i) => i.id === Number(request.params.id));
+    if (!item) {
+      return reply.code(404).send({ message: 'Item not found' });
+    }
+    if (request.body.name !== undefined) {
+      item.name = request.body.name;
+    }
+    if (request.body.description !== undefined) {
+      item.description = request.body.description;
+    }
+    return item;
+  });
+
+  app.delete<{ Params: { id: number }; Reply: { message: string } | { message: string } }>('/items/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      response: {
+        200: messageSchema,
+        404: messageSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const index = items.findIndex((i) => i.id === Number(request.params.id));
+    if (index === -1) {
+      return reply.code(404).send({ message: 'Item not found' });
+    }
+    items.splice(index, 1);
+    return { message: 'Item deleted' };
+  });
+};
+
+export default itemsRoutes;

--- a/backend/routes/users.ts
+++ b/backend/routes/users.ts
@@ -1,0 +1,126 @@
+import { FastifyPluginAsync } from 'fastify';
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+const users: User[] = [];
+let nextId = 1;
+
+const userSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'integer' },
+    name: { type: 'string' },
+    email: { type: 'string' },
+  },
+  required: ['id', 'name', 'email'],
+};
+
+const messageSchema = {
+  type: 'object',
+  properties: { message: { type: 'string' } },
+  required: ['message'],
+};
+
+const usersRoutes: FastifyPluginAsync = async (app) => {
+  app.get<{ Reply: User[] }>('/users', {
+    schema: { response: { 200: { type: 'array', items: userSchema } } },
+  }, async () => users);
+
+  app.get<{ Params: { id: number }; Reply: User | { message: string } }>('/users/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      response: {
+        200: userSchema,
+        404: messageSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const user = users.find((u) => u.id === Number(request.params.id));
+    if (!user) {
+      return reply.code(404).send({ message: 'User not found' });
+    }
+    return user;
+  });
+
+  app.post<{ Body: Omit<User, 'id'>; Reply: User }>('/users', {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+        },
+        required: ['name', 'email'],
+      },
+      response: { 200: userSchema },
+    },
+  }, async (request) => {
+    const newUser: User = { id: nextId++, ...request.body };
+    users.push(newUser);
+    return newUser;
+  });
+
+  app.put<{ Params: { id: number }; Body: Partial<Omit<User, 'id'>>; Reply: User | { message: string } }>('/users/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      body: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          email: { type: 'string' },
+        },
+      },
+      response: {
+        200: userSchema,
+        404: messageSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const user = users.find((u) => u.id === Number(request.params.id));
+    if (!user) {
+      return reply.code(404).send({ message: 'User not found' });
+    }
+    if (request.body.name !== undefined) {
+      user.name = request.body.name;
+    }
+    if (request.body.email !== undefined) {
+      user.email = request.body.email;
+    }
+    return user;
+  });
+
+  app.delete<{ Params: { id: number }; Reply: { message: string } | { message: string } }>('/users/:id', {
+    schema: {
+      params: {
+        type: 'object',
+        properties: { id: { type: 'integer' } },
+        required: ['id'],
+      },
+      response: {
+        200: messageSchema,
+        404: messageSchema,
+      },
+    },
+  }, async (request, reply) => {
+    const index = users.findIndex((u) => u.id === Number(request.params.id));
+    if (index === -1) {
+      return reply.code(404).send({ message: 'User not found' });
+    }
+    users.splice(index, 1);
+    return { message: 'User deleted' };
+  });
+};
+
+export default usersRoutes;

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,10 +1,15 @@
 import fastify from 'fastify';
+import usersRoutes from './routes/users.js';
+import itemsRoutes from './routes/items.js';
 
 const app = fastify({ logger: true });
 
 app.get('/ping', async (_request, _reply) => {
   return { pong: 'it works!' };
 });
+
+app.register(usersRoutes);
+app.register(itemsRoutes);
 
 const start = async () => {
   try {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,5 +8,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["server.ts"]
+  "include": ["server.ts", "routes/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- scaffold new Fastify route modules in backend
- register CRUD routes in `server.ts`
- compile TypeScript from the `routes` directory
- document example `curl` usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6f8c06f88331b52e10ea204202f8